### PR TITLE
Add x86_64 support in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
+FROM blackdex/rust-musl:aarch64-musl AS rust_musl_arm64
+FROM blackdex/rust-musl:x86_64-musl AS rust_musl_amd64
+
 # Install cargo-chef
-FROM blackdex/rust-musl:aarch64-musl AS chef
+ARG TARGETARCH
+FROM rust_musl_${TARGETARCH} AS chef
 USER root
 RUN cargo install cargo-chef
 WORKDIR /build
@@ -12,15 +16,16 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Build the servers
 FROM chef AS builder
 COPY --from=planner /build/recipe.json recipe.json
-RUN cargo chef cook --release --target aarch64-unknown-linux-musl --recipe-path recipe.json
+RUN cargo chef cook --release --target $(uname -m)-unknown-linux-musl --recipe-path recipe.json
 COPY . .
-RUN cargo build --release --target aarch64-unknown-linux-musl
+RUN cargo build --release --target $(uname -m)-unknown-linux-musl && \
+    cp /build/target/$(uname -m)-unknown-linux-musl/release/minibit /build/minibit
 
 # Build the runtime image
 FROM alpine:3.23 AS runtime
 WORKDIR /run
 RUN mkdir -p /bin
-COPY --from=builder /build/target/aarch64-unknown-linux-musl/release/minibit /bin/minibit
+COPY --from=builder /build/minibit /bin/minibit
 
 EXPOSE 25565
 CMD ["/bin/minibit"]


### PR DESCRIPTION
Adds support for building the Dockerfile on x86_64 (#10).

Uses `TARGETARCH` and `uname -m` to automatically determine the correct architecture.