### PR TITLE
Fix system ordering for duels which copy their maps

### DIFF
--- a/src/lib/duels/copied_map.rs
+++ b/src/lib/duels/copied_map.rs
@@ -19,9 +19,9 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-use valence::layer::UpdateLayersPreClientSet;
 use super::*;
 use crate::config::DataPath;
+use valence::layer::UpdateLayersPreClientSet;
 use valence::prelude::*;
 use valence_anvil::AnvilLevel;
 
@@ -48,7 +48,10 @@ impl<T: Resource + DeserializeOwned + DuelsConfig + Sync + Send + 'static> Plugi
     fn build(&self, app: &mut App) {
         app.add_systems(Startup, setup::<T>)
             .add_systems(Update, (init_clients::<T>,))
-            .add_systems(PostUpdate, (check_queue::<T>, end_game::<T>).before(UpdateLayersPreClientSet));
+            .add_systems(
+                PostUpdate,
+                (check_queue::<T>, end_game::<T>).before(UpdateLayersPreClientSet),
+            );
     }
 }
 


### PR DESCRIPTION
Orders `check_queue` and `end_game` in `copied_map.rs` before `UpdateLayersPreClientSet` as they modify chunk and entity layers, preventing a race condition.

To reproduce the problem before this change, run `cargo run -p stresser -r -- --target 127.0.0.1:25565 -c 1000` with a `config.yml` containing:
```yml
bridge:
  enabled: true
  path: bridge
  network:
    port: 25565
    max_players: 1000
```