### PR TITLE
Add a scoreboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,9 +515,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.52"
+version = "1.2.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
+checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -935,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
+checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
 
 [[package]]
 name = "fixedbitset"
@@ -1572,6 +1572,7 @@ dependencies = [
  "diesel",
  "fastrand",
  "figment",
+ "itoa",
  "parry3d",
  "serde",
  "serde_json",
@@ -1947,9 +1948,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -1981,7 +1982,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -2002,7 +2003,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2260,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.2"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2270,9 +2271,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2458,7 +2459,7 @@ checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -2590,11 +2591,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2610,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3863,6 +3864,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
+checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.5.54", features = ["derive", "cargo"] }
 diesel = { version = "2.2.7", features = ["chrono", "numeric", "postgres", "serde_json"] }
 fastrand = "2.1.0"
 figment = { version = "0.10.19", features = ["env", "yaml"] }
+itoa = "1.0.17"
 parry3d = "0.17.0"
 serde = "1.0.204"
 serde_json = "1.0.120"

--- a/src/bin/minibit/subservers/lobby.rs
+++ b/src/bin/minibit/subservers/lobby.rs
@@ -31,6 +31,7 @@ use valence::{
 };
 use valence_anvil::AnvilLevel;
 use minibit_lib::config::DataPath;
+use minibit_lib::scoreboard::{ScoreboardMode, ScoreboardPlugin};
 use crate::ServerConfig;
 
 #[derive(Deserialize, Clone)]
@@ -99,7 +100,11 @@ pub fn main(config: ServerConfig) {
             phantom: PhantomData,
         })
         .add_plugins(DefaultPlugins)
-        .add_plugins((ScopePlugin, commands::CommandPlugin, InteractionBroadcastPlugin))
+        .add_plugins((ScopePlugin, commands::CommandPlugin, ScoreboardPlugin {
+            name: "MINIBIT",
+            text: vec!["Welcome to MiniBit!"],
+            mode: ScoreboardMode::ServerWide,
+        }, InteractionBroadcastPlugin))
         .insert_resource(ServerGlobals {
             navigator_gui: None,
         })

--- a/src/lib/color.rs
+++ b/src/lib/color.rs
@@ -18,6 +18,31 @@
 
 #![allow(dead_code)]
 
+pub mod format {
+    pub const DARK_RED: &str = "\u{00A7}4";
+    pub const RED: &str = "\u{00A7}c";
+    pub const GOLD: &str = "\u{00A7}6";
+    pub const YELLOW: &str = "\u{00A7}e";
+    pub const DARK_GREEN: &str = "\u{00A7}2";
+    pub const GREEN: &str = "\u{00A7}a";
+    pub const AQUA: &str = "\u{00A7}b";
+    pub const DARK_AQUA: &str = "\u{00A7}3";
+    pub const DARK_BLUE: &str = "\u{00A7}1";
+    pub const BLUE: &str = "\u{00A7}9";
+    pub const LIGHT_PURPLE: &str = "\u{00A7}d";
+    pub const DARK_PURPLE: &str = "\u{00A7}5";
+    pub const WHITE: &str = "\u{00A7}f";
+    pub const GRAY: &str = "\u{00A7}7";
+    pub const DARK_GRAY: &str = "\u{00A7}8";
+    pub const BLACK: &str = "\u{00A7}0";
+    pub const OBFUSCATED: &str = "\u{00A7}k";
+    pub const BOLD: &str = "\u{00A7}l";
+    pub const STRIKETHROUGH: &str = "\u{00A7}m";
+    pub const UNDERLINE: &str = "\u{00A7}n";
+    pub const ITALIC: &str = "\u{00A7}o";
+    pub const RESET: &str = "\u{00A7}r";
+}
+
 pub enum ArmorColors {
     Red = 11546150,
     Orange = 16351261,

--- a/src/lib/duels/copied_map.rs
+++ b/src/lib/duels/copied_map.rs
@@ -161,6 +161,7 @@ pub fn check_queue<T: Resource + DuelsConfig>(
     )>,
     mut start_game_ev: EventWriter<StartGameEvent>,
     config: Res<T>,
+    globals: Res<MapGlobals>,
     server: Res<Server>,
     dimensions: Res<DimensionTypeRegistry>,
     biomes: Res<BiomeRegistry>,
@@ -181,6 +182,7 @@ pub fn check_queue<T: Resource + DuelsConfig>(
             &server,
             &dimensions,
             &biomes,
+            &globals,
             &config,
             &data_path,
         );
@@ -204,6 +206,7 @@ fn start_game<T: Resource + DuelsConfig>(
     server: &Res<Server>,
     dimensions: &Res<DimensionTypeRegistry>,
     biomes: &Res<BiomeRegistry>,
+    globals: &Res<MapGlobals>,
     config: &Res<T>,
     data_path: &Res<DataPath>,
 ) {
@@ -241,7 +244,7 @@ fn start_game<T: Resource + DuelsConfig>(
 
         layer_id.0 = layer;
         visible_chunk_layer.0 = layer;
-        visible_entity_layers.0.clear();
+        visible_entity_layers.0.remove(&globals.queue_layer);
         visible_entity_layers.0.insert(layer);
 
         gamestate.game_id = Some(game_id);
@@ -295,7 +298,7 @@ pub fn end_game<T: Resource + DuelsConfig>(
             };
             layer_id.0 = globals.queue_layer;
             visible_chunk_layer.0 = globals.queue_layer;
-            visible_entity_layers.0.clear();
+            visible_entity_layers.0.remove(&layer_id);
             visible_entity_layers.0.insert(globals.queue_layer);
             pos.set(config.worlds()[0].spawns[0].pos);
             health.0 = 20.0;

--- a/src/lib/duels/map.rs
+++ b/src/lib/duels/map.rs
@@ -203,7 +203,7 @@ pub fn start_game<T: Resource + DuelsConfig>(
 
                 layer_id.0 = entitylayer;
                 visible_chunk_layer.0 = chunklayer;
-                visible_entity_layers.0.clear();
+                visible_entity_layers.0.remove(&globals.map_layers[0]);
                 visible_entity_layers.0.insert(entitylayer);
 
                 gamestate.game_id = Some(event.0);
@@ -257,7 +257,7 @@ pub fn end_game<T: Resource + DuelsConfig>(
             };
             layer_id.0 = globals.map_layers[0];
             visible_chunk_layer.0 = globals.map_layers[0];
-            visible_entity_layers.0.clear();
+            visible_entity_layers.0.remove(&layer_id);
             visible_entity_layers.0.insert(globals.map_layers[0]);
             pos.set(config.worlds()[0].spawns[0].pos);
             health.0 = 20.0;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -26,4 +26,5 @@ pub mod food;
 pub mod player;
 pub mod projectiles;
 pub mod scopes;
+pub mod scoreboard;
 pub mod world;

--- a/src/lib/scoreboard.rs
+++ b/src/lib/scoreboard.rs
@@ -1,0 +1,162 @@
+/*
+    MiniBit - A Minecraft minigame server network written in Rust.
+    Copyright (C) 2024  Cheezer1656 (https://github.com/Cheezer1656/)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#![allow(dead_code)]
+
+use valence::{
+    prelude::*,
+    scoreboard::{Objective, ObjectiveBundle, ObjectiveDisplay, ObjectiveScores},
+};
+
+use super::color::format;
+
+#[derive(Component)]
+pub struct ScoreboardId(pub Entity);
+
+pub enum ScoreboardMode {
+    ServerWide,
+    PerPlayer,
+}
+
+#[derive(Resource)]
+pub struct ScoreboardGlobals {
+    pub layer: EntityLayerId,
+}
+
+#[derive(Resource)]
+pub struct ScoreboardPluginResource {
+    name: &'static str,
+    text: Vec<&'static str>,
+}
+
+pub struct ScoreboardPlugin {
+    pub name: &'static str,
+    pub text: Vec<&'static str>,
+    pub mode: ScoreboardMode,
+}
+
+impl Plugin for ScoreboardPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(ScoreboardPluginResource {
+            name: self.name,
+            text: self.text.clone(),
+        });
+
+        match self.mode {
+            ScoreboardMode::ServerWide => {
+                app.add_systems(Startup, setup)
+                    .add_systems(Update, init_clients_0);
+            }
+            ScoreboardMode::PerPlayer => {
+                app.add_systems(Update, (init_clients_1, cleanup_clients));
+            }
+        }
+    }
+}
+
+pub fn setup(mut commands: Commands, server: Res<Server>, res: Res<ScoreboardPluginResource>) {
+    let obj_layer_id = commands.spawn(EntityLayer::new(&server)).id();
+    commands.insert_resource(ScoreboardGlobals {
+        layer: EntityLayerId(obj_layer_id),
+    });
+    let obj = init_objective_bundle("sidebar", res.name, EntityLayerId(obj_layer_id), &res.text);
+    commands.spawn(obj);
+}
+
+pub fn init_clients_0(
+    mut clients: Query<&mut VisibleEntityLayers, Added<Client>>,
+    globals: Res<ScoreboardGlobals>,
+) {
+    for mut layers in clients.iter_mut() {
+        layers.0.insert(globals.layer.0);
+    }
+}
+
+pub fn init_clients_1(
+    mut commands: Commands,
+    mut clients: Query<(Entity, &mut VisibleEntityLayers), Added<Client>>,
+    server: Res<Server>,
+    res: Res<ScoreboardPluginResource>,
+) {
+    for (entity, mut layers) in clients.iter_mut() {
+        let layer = EntityLayer::new(&server);
+        let obj = init_objective_bundle("sidebar", res.name, EntityLayerId(entity), &res.text);
+        let obj_id = commands.spawn(obj).id();
+        commands
+            .entity(entity)
+            .insert((layer, ScoreboardId(obj_id)));
+        layers.0.insert(entity);
+    }
+}
+
+pub fn cleanup_clients(
+    mut commands: Commands,
+    clients: Query<&ScoreboardId>,
+    mut removed: RemovedComponents<Client>,
+) {
+    for entity in removed.read() {
+        if let Ok(ScoreboardId(obj_id)) = clients.get(entity) {
+            commands.entity(*obj_id).despawn();
+        }
+    }
+}
+
+fn init_objective_bundle(
+    name: &str,
+    display: &'static str,
+    layer: EntityLayerId,
+    text: &Vec<&str>,
+) -> ObjectiveBundle {
+    ObjectiveBundle {
+        name: Objective::new(name),
+        display: ObjectiveDisplay(display.color(Color::GOLD).bold()),
+        layer,
+        scores: gen_scores(text),
+        ..Default::default()
+    }
+}
+
+pub fn gen_scores<T: AsRef<str> + ToString>(text: &[T]) -> ObjectiveScores {
+    let mut scores = ObjectiveScores::new();
+    scores.insert(
+        format::DARK_GRAY.to_string()
+            + format::BOLD
+            + format::STRIKETHROUGH
+            + "-------------------",
+        text.len() as i32 + 4,
+    );
+    scores.insert("  ", text.len() as i32 + 3);
+    scores.insert("", 2);
+    scores.insert(
+        format::DARK_GRAY.to_string()
+            + format::BOLD
+            + format::STRIKETHROUGH
+            + "------------------ ",
+        1,
+    );
+    scores.insert(format::YELLOW.to_string() + "minibit.net", 0);
+    for (i, line) in text.iter().rev().enumerate() {
+        let mut line = line.to_string();
+        while scores.get(&line).is_some() {
+            line.push(' ');
+        }
+        scores.insert(line, 3 + i as i32);
+    }
+
+    scores
+}


### PR DESCRIPTION
- Adds a `ScoreboardPlugin` that makes it easy to have consistent-looking scoreboards across all the minigames
- Adds a scoreboard to the bridge minigame that keeps track of goals, kills, and deaths
- Adds a scoreboard to the lobby with a welcome message